### PR TITLE
Format newlines so as not to disturb tree rendering.

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,15 +12,16 @@ foo
 │   └── b
 ├── baz
 └── qux
-    └── c
+    └── c⏎
+        d
 ```
 
 using code like this:
 
 ```python
-import operator
+from operator import itemgetter
 
-from tree_format import print_tree
+from tree_format import format_tree
 
 tree = (
     'foo', [
@@ -30,14 +31,13 @@ tree = (
         ]),
         ('baz', []),
         ('qux', [
-            ('c', []),
+            ('c\nd', []),
         ]),
     ],
 )
 
 print format_tree(
     tree, format_node=itemgetter(0), get_children=itemgetter(1))
-
 ```
 
 ## License

--- a/tree_format/_text.py
+++ b/tree_format/_text.py
@@ -40,7 +40,6 @@ def _format_newlines(prefix, formatted_node):
     return formatted_node.replace(u'\n', replacement)
 
 
-
 def _format_tree(node, format_node, get_children, prefix=u''):
     children = list(get_children(node))
     next_prefix = u''.join([prefix, VERTICAL, u'   '])

--- a/tree_format/_text.py
+++ b/tree_format/_text.py
@@ -24,6 +24,21 @@ FORK = u'\u251c'
 LAST = u'\u2514'
 VERTICAL = u'\u2502'
 HORIZONTAL = u'\u2500'
+NEWLINE = u'\u23ce'
+
+
+def _format_newlines(prefix, formatted_node):
+    """
+    Convert newlines into U+23EC characters, followed by an actual newline and
+    then a tree prefix so as to position the remaining text under the previous
+    line.
+    """
+    replacement = u''.join([
+        NEWLINE,
+        u'\n',
+        prefix])
+    return formatted_node.replace(u'\n', replacement)
+
 
 
 def _format_tree(node, format_node, get_children, prefix=u''):
@@ -35,7 +50,8 @@ def _format_tree(node, format_node, get_children, prefix=u''):
                         HORIZONTAL,
                         HORIZONTAL,
                         u' ',
-                        format_node(child)])
+                        _format_newlines(next_prefix,
+                                         format_node(child))])
         for result in _format_tree(child,
                                    format_node,
                                    get_children,
@@ -48,7 +64,8 @@ def _format_tree(node, format_node, get_children, prefix=u''):
                         HORIZONTAL,
                         HORIZONTAL,
                         u' ',
-                        format_node(children[-1])])
+                        _format_newlines(last_prefix,
+                                         format_node(children[-1]))])
         for result in _format_tree(children[-1],
                                    format_node,
                                    get_children,

--- a/tree_format/tests/test_text.py
+++ b/tree_format/tests/test_text.py
@@ -107,6 +107,32 @@ class TestFormatTree(TestCase):
                 doctest.REPORT_NDIFF))
 
 
+    def test_newlines(self):
+        tree = (
+            'foo', [
+                ('bar\nfrob', [
+                    ('a', []),
+                    ('b\nc\nd', []),
+                ]),
+                ('baz', []),
+                ('qux\nfrab', []),
+            ],
+        )
+        output = self.format_tree(tree)
+        self.assertEqual(dedent(u'''\
+        foo
+        ├── bar⏎
+        │   frob
+        │   ├── a
+        │   └── b⏎
+        │       c⏎
+        │       d
+        ├── baz
+        └── qux⏎
+            frab
+        '''), output)
+
+
 def d(name, files):
     return (name, files)
 

--- a/tree_format/tests/test_text.py
+++ b/tree_format/tests/test_text.py
@@ -106,7 +106,6 @@ class TestFormatTree(TestCase):
                 doctest.NORMALIZE_WHITESPACE |
                 doctest.REPORT_NDIFF))
 
-
     def test_newlines(self):
         tree = (
             'foo', [


### PR DESCRIPTION
Other undesirable characters should be escaped by user code.

Fixes #4.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jml/tree-format/9)
<!-- Reviewable:end -->
