### PR TITLE
Make an assumption about the encoding of `README.md` for `setup.py`.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,12 +14,14 @@
 # limitations under the License.
 
 
+import codecs
 import os
 
 from setuptools import find_packages, setup
 
 
-with open(os.path.join(os.path.dirname(__file__), "README.md")) as readme:
+readme_path = os.path.join(os.path.dirname(__file__), "README.md")
+with codecs.open(readme_path, encoding='utf-8', errors='replace') as readme:
     long_description = readme.read()
 
 classifiers = [


### PR DESCRIPTION
Without this, sometimes Windows blows up (I'm not quite sure why) trying to
decode the UTF-8 as CP1252.

Fixes #10.