### PR TITLE
 Make tree print characters configurable; Introduce format_ascii_tree

### DIFF
--- a/tree_format/_text.py
+++ b/tree_format/_text.py
@@ -43,7 +43,7 @@ def _format_newlines(prefix, formatted_node, options):
     """
     replacement = u''.join([
         options.NEWLINE,
-        '\n',
+        u'\n',
         prefix])
     return formatted_node.replace(u'\n', replacement)
 
@@ -98,11 +98,11 @@ def format_ascii_tree(tree, format_node, get_children):
     return format_tree(tree,
                        format_node,
                        get_children,
-                       Options(FORK='|',
-                               LAST='+',
-                               VERTICAL='|',
-                               HORIZONTAL='-',
-                               NEWLINE='\n'))
+                       Options(FORK=u'|',
+                               LAST=u'+',
+                               VERTICAL=u'|',
+                               HORIZONTAL=u'-',
+                               NEWLINE=u'\n'))
 
 
 def print_tree(*args, **kwargs):

--- a/tree_format/_text.py
+++ b/tree_format/_text.py
@@ -20,65 +20,89 @@
 import itertools
 
 
-FORK = u'\u251c'
-LAST = u'\u2514'
-VERTICAL = u'\u2502'
-HORIZONTAL = u'\u2500'
-NEWLINE = u'\u23ce'
+class Options(object):
+
+    def __init__(self,
+                 FORK=u'\u251c',
+                 LAST=u'\u2514',
+                 VERTICAL=u'\u2502',
+                 HORIZONTAL=u'\u2500',
+                 NEWLINE=u'\u23ce'):
+        self.FORK = FORK
+        self.LAST = LAST
+        self.VERTICAL = VERTICAL
+        self.HORIZONTAL = HORIZONTAL
+        self.NEWLINE = NEWLINE
 
 
-def _format_newlines(prefix, formatted_node):
+def _format_newlines(prefix, formatted_node, options):
     """
     Convert newlines into U+23EC characters, followed by an actual newline and
     then a tree prefix so as to position the remaining text under the previous
     line.
     """
     replacement = u''.join([
-        NEWLINE,
-        u'\n',
+        options.NEWLINE,
+        '\n',
         prefix])
     return formatted_node.replace(u'\n', replacement)
 
 
-def _format_tree(node, format_node, get_children, prefix=u''):
+def _format_tree(node, format_node, get_children, options, prefix=u''):
     children = list(get_children(node))
-    next_prefix = u''.join([prefix, VERTICAL, u'   '])
+    next_prefix = u''.join([prefix, options.VERTICAL, u'   '])
     for child in children[:-1]:
         yield u''.join([prefix,
-                        FORK,
-                        HORIZONTAL,
-                        HORIZONTAL,
+                        options.FORK,
+                        options.HORIZONTAL,
+                        options.HORIZONTAL,
                         u' ',
                         _format_newlines(next_prefix,
-                                         format_node(child))])
+                                         format_node(child),
+                                         options)])
         for result in _format_tree(child,
                                    format_node,
                                    get_children,
+                                   options,
                                    next_prefix):
             yield result
     if children:
         last_prefix = u''.join([prefix, u'    '])
         yield u''.join([prefix,
-                        LAST,
-                        HORIZONTAL,
-                        HORIZONTAL,
+                        options.LAST,
+                        options.HORIZONTAL,
+                        options.HORIZONTAL,
                         u' ',
                         _format_newlines(last_prefix,
-                                         format_node(children[-1]))])
+                                         format_node(children[-1]),
+                                         options)])
         for result in _format_tree(children[-1],
                                    format_node,
                                    get_children,
+                                   options,
                                    last_prefix):
             yield result
 
 
-def format_tree(node, format_node, get_children):
+def format_tree(node, format_node, get_children, options=Options()):
     lines = itertools.chain(
         [format_node(node)],
-        _format_tree(node, format_node, get_children),
+        _format_tree(node, format_node, get_children, options),
         [u''],
     )
     return u'\n'.join(lines)
+
+
+def format_ascii_tree(tree, format_node, get_children):
+    """ Formats the tree using only ascii characters """
+    return format_tree(tree,
+                       format_node,
+                       get_children,
+                       Options(FORK='|',
+                               LAST='+',
+                               VERTICAL='|',
+                               HORIZONTAL='-',
+                               NEWLINE='\n'))
 
 
 def print_tree(*args, **kwargs):

--- a/tree_format/_text.py
+++ b/tree_format/_text.py
@@ -35,6 +35,13 @@ class Options(object):
         self.NEWLINE = NEWLINE
 
 
+ASCII_OPTIONS = Options(FORK=u'|',
+                        LAST=u'+',
+                        VERTICAL=u'|',
+                        HORIZONTAL=u'-',
+                        NEWLINE=u'\n')
+
+
 def _format_newlines(prefix, formatted_node, options):
     """
     Convert newlines into U+23EC characters, followed by an actual newline and
@@ -84,10 +91,10 @@ def _format_tree(node, format_node, get_children, options, prefix=u''):
             yield result
 
 
-def format_tree(node, format_node, get_children, options=Options()):
+def format_tree(node, format_node, get_children, options=None):
     lines = itertools.chain(
         [format_node(node)],
-        _format_tree(node, format_node, get_children, options),
+        _format_tree(node, format_node, get_children, options or Options()),
         [u''],
     )
     return u'\n'.join(lines)
@@ -98,11 +105,7 @@ def format_ascii_tree(tree, format_node, get_children):
     return format_tree(tree,
                        format_node,
                        get_children,
-                       Options(FORK=u'|',
-                               LAST=u'+',
-                               VERTICAL=u'|',
-                               HORIZONTAL=u'-',
-                               NEWLINE=u'\n'))
+                       ASCII_OPTIONS)
 
 
 def print_tree(*args, **kwargs):

--- a/tree_format/tests/test_text.py
+++ b/tree_format/tests/test_text.py
@@ -22,7 +22,7 @@ from testtools import TestCase
 from testtools.matchers import DocTestMatches
 
 from .._text import (
-    format_tree,
+    format_tree, format_ascii_tree,
 )
 
 
@@ -30,6 +30,9 @@ class TestFormatTree(TestCase):
 
     def format_tree(self, tree):
         return format_tree(tree, itemgetter(0), itemgetter(1))
+
+    def format_ascii_tree(self, tree):
+        return format_ascii_tree(tree, itemgetter(0), itemgetter(1))
 
     def test_single_node_tree(self):
         tree = ('foo', [])
@@ -130,6 +133,28 @@ class TestFormatTree(TestCase):
         └── qux⏎
             frab
         '''), output)
+
+    def test_ascii__tree(self):
+        tree = (
+            'foo', [
+                ('bar', [
+                    ('a', []),
+                    ('b', []),
+                ]),
+                ('baz', []),
+                ('qux', []),
+            ],
+        )
+        output = self.format_ascii_tree(tree)
+        self.assertEqual(dedent(u'''\
+        foo
+        |-- bar
+        |   |-- a
+        |   +-- b
+        |-- baz
+        +-- qux
+        '''), output)
+
 
 
 def d(name, files):

--- a/tree_format/tests/test_text.py
+++ b/tree_format/tests/test_text.py
@@ -156,7 +156,6 @@ class TestFormatTree(TestCase):
         '''), output)
 
 
-
 def d(name, files):
     return (name, files)
 


### PR DESCRIPTION
I work on a project where we need to support pure ASCII output.

Previously, the characters the tree used for printing the tree were hard-coded,
and because they were non-ASCII this means I cannot use this library for my project.

Now the print characters are configurable using an optional 'option' parameter passed into format_tree.

I also used this to introduce a 'format_ascii_tree' which uses only ASCII based
print characters.